### PR TITLE
build: add Unix-only compile guard

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(not(unix))]
+compile_error!("git-autosnap is Unix-only; build requires cfg(unix).");
+
 pub mod app;
 pub mod cli;
 pub mod commands;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+#[cfg(not(unix))]
+compile_error!("git-autosnap is Unix-only; build requires cfg(unix).");
+
 use anyhow::Result;
 use clap::Parser;
 use git_autosnap::{


### PR DESCRIPTION
## Summary

Adds compile-time guards to enforce Unix-only builds for git-autosnap, preventing compilation on non-Unix platforms where the application cannot function properly.

## Changes

- Add `#[cfg(not(unix))]` compile guard to `src/lib.rs`
- Add `#[cfg(not(unix))]` compile guard to `src/main.rs`
- Both guards emit clear error message: "git-autosnap is Unix-only; build requires cfg(unix)."

## Motivation

git-autosnap relies on Unix-specific functionality for file system watching, signal handling, and daemon management. This change prevents users from attempting to build on incompatible platforms like Windows, providing clear feedback at compile time rather than runtime failures.

## Technical Details

Uses Rust's conditional compilation attributes to check the target platform during compilation. If the target is not Unix, compilation fails with a descriptive error message explaining the platform requirement.

## Impact

- **Affected features**: Build system and platform compatibility
- **Affected files**: Core entry points (`src/lib.rs`, `src/main.rs`)
- **Breaking changes**: No - existing Unix builds continue to work unchanged

## Testing

1. Verify Unix builds continue to work: `cargo build`
2. Confirm error message appears on non-Unix targets (if available for testing)
3. Existing pre-commit hooks passed (check, clippy, fmt, test-unit)

## Checklist

- [x] Code works as expected
- [x] Tests have been added/updated (not applicable for compile-time guards)
- [x] Documentation has been updated (if necessary)
- [x] Linter and formatter have been run
- [x] Breaking changes are clearly documented