### PR TITLE
refactor: replace unsafe libc calls with nix equivalents for improved safety

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,7 +1058,6 @@ dependencies = [
  "fs2",
  "git2",
  "ignore-files",
- "libc",
  "nix 0.30.1",
  "predicates",
  "shell-escape",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ watchexec = "8.0.1"
 watchexec-filterer-ignore = "7.0.0"
 ignore-files = "3.0.4"
 fs2 = "0.4.3"
-libc = "0.2"
 time = { version = "0.3.36", features = ["formatting", "local-offset"] }
 tempfile = "=3.21.0"
 skim = "0.20.5"


### PR DESCRIPTION
## Summary

This PR removes the `libc` dependency and replaces unsafe C bindings with safer Rust equivalents from the `nix` crate. This improves code safety by eliminating raw `libc` calls and reducing unsafe code blocks in the daemon and process management modules.

## Changes

- **Removed unused `libc` dependency** from `Cargo.toml` and `Cargo.lock`
- **Replaced `libc::setsid()` with `nix::unistd::setsid()`** in daemon.rs for process session management
- **Replaced `/bin/kill -0` subprocess with `nix::sys::signal::kill()`** in process.rs for PID liveness checking
- **Added proper error handling** for Unix system calls with nix's typed error system
- **Maintained cross-platform compatibility** with conditional compilation for non-Unix systems

## Motivation

The previous implementation used unsafe `libc` calls and subprocess execution for basic Unix operations. This approach had several drawbacks:
- **Safety concerns**: Direct `libc` calls require unsafe blocks and manual error handling
- **Process overhead**: Using `/bin/kill -0` subprocess for PID checking is inefficient
- **Error handling**: Raw C return codes are harder to handle correctly than typed Rust errors

The `nix` crate provides safe, idiomatic Rust wrappers around Unix system calls, eliminating the need for unsafe code while maintaining the same functionality.

## Technical Details

### Daemon Process Creation (`src/core/runtime/daemon.rs`)
- Replaced `libc::setsid()` with `nix::unistd::setsid()` 
- Added proper error conversion from nix errors to `std::io::Error`
- Maintained the same functionality of creating a new session to detach from controlling terminal

### PID Liveness Checking (`src/core/runtime/process.rs`)
- Replaced subprocess call to `/bin/kill -0` with direct `nix::sys::signal::kill()` call
- Implemented proper signal semantics:
  - `Ok(())` → process exists and is accessible  
  - `EPERM` → process exists but lacks permission (treated as alive)
  - `ESRCH` → no such process (dead)
  - Other errors → treated as not alive for safety
- Added conditional compilation for non-Unix platforms

## Impact

- **Improved safety**: Eliminated unsafe blocks and raw C bindings
- **Better error handling**: Typed errors instead of raw return codes  
- **Reduced dependencies**: Removed unused `libc` dependency
- **Performance improvement**: Direct syscalls instead of subprocess execution for PID checking
- **No breaking changes**: Public API and functionality remain identical

## Testing

The changes maintain existing behavior and should pass all current tests:

```bash
# Run unit tests
task test-unit

# Run full test suite including container tests
task test

# Verify daemon functionality 
git autosnap start
git autosnap status
git autosnap stop
```

## Checklist

- [x] Code works locally and maintains existing functionality
- [x] No new unsafe code introduced
- [x] Error handling improved with typed nix errors
- [x] Cross-platform compatibility maintained
- [x] Dependencies cleaned up (removed unused libc)
- [x] Existing tests should continue to pass

## Additional Notes

This refactoring is part of improving the overall code quality and safety of the git-autosnap project by reducing unsafe code and leveraging Rust's type system for better error handling. The `nix` crate is already a dependency, so this change consolidates Unix system call handling to a single, well-maintained library.